### PR TITLE
Pin lit-element version to 2.5.1

### DIFF
--- a/public_html/js/namedayElement.js
+++ b/public_html/js/namedayElement.js
@@ -1,4 +1,4 @@
-import {LitElement, html, css, customElement, property} from 'https://unpkg.com/lit-element/lit-element.js?module';
+import {LitElement, html, css, customElement, property} from 'https://unpkg.com/lit-element@2.5.1/lit-element.js?module';
 
 // commented code is TypeScript
 //            @customElement('nameday-element')


### PR DESCRIPTION
There are breaking changes in 3.x and 4.x, this version "just works".